### PR TITLE
Feature/changeable merge language

### DIFF
--- a/config/mandrill-template.php
+++ b/config/mandrill-template.php
@@ -6,4 +6,6 @@ return [
     'templates' => [],
 
     'default_template' => '',
+
+    'merge_language' => 'handlebars', // handlebars or mailchimp
 ];

--- a/src/Mandrill/Message.php
+++ b/src/Mandrill/Message.php
@@ -589,7 +589,7 @@ class Message implements Arrayable
             'headers'             => $this->headers,
             'preserve_recipients' => $this->preserveRecipients,
             'merge'               => true,
-            'merge_language'      => 'handlebars',
+            'merge_language'      => config('mandrill-template.merge_language', 'handlebars'),
             'global_merge_vars'   => Utils\ArrayHelper::assocToNameContent($this->mergeVars),
             'merge_vars'          => $mergeVars,
             'tags'                => $this->tags,


### PR DESCRIPTION
Hello, currently `merge_language` variable is hard coded, but we use `mailchimp` merge language instead because Mailchimp exports templates to Mandrill using this one by default.