### PR TITLE
php 8.2 compatible

### DIFF
--- a/src/MandrillTemplate.php
+++ b/src/MandrillTemplate.php
@@ -11,7 +11,7 @@ class MandrillTemplate
     /**
      * @var \Mandrill
      */
-    protected $client;
+    protected $api;
 
     /**
      * MandrillTemplate constructor.


### PR DESCRIPTION
The property `api` works as a dynamic one, it is deprecated in [PHP 8.2](https://www.php.net/releases/8.2/en.php#deprecate_dynamic_properties). Also, I've removed the redundant `client` property.